### PR TITLE
Automate bump to copyright year range

### DIFF
--- a/.github/workflows/bump-copyright-year-range.yml
+++ b/.github/workflows/bump-copyright-year-range.yml
@@ -1,0 +1,36 @@
+name: Bump Copyright Year Range
+
+on:
+  schedule:
+    # Run on Jan 1st at 00:00 UTC every year
+    - cron: '0 0 1 1 *'
+  workflow_dispatch:  # allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  bump-copyright-year-range:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Bump copyright year range
+        run: |
+          YEAR=$(date +'%Y')
+          # Update README.md
+          sed -E -i 's|(Copyright \(C\) 20[0-9]{2}-)[0-9]{4}|\1'"$YEAR"'|' README.md
+          # Update footer.html.ep
+          sed -E -i 's|(<i class="far fa-copyright"></i> 20[0-9]{2}-)[0-9]{4}|\1'"$YEAR"'|' templates/footer.html.ep
+
+      - name: Commit changes if any
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add README.md templates/footer.html.ep
+          if ! git diff --cached --quiet; then
+            git commit -m 'Happy New Year!'
+            git push
+          fi


### PR DESCRIPTION
Hi!

I noticed that the copyright notice was overdue for an update of the year range, so I thought that instead of PR’ing that change, I would rather PR its automation.

Ah, you'll have to manually trigger the workflow for this year, though.

Hope that it helps.

Happy New Year! :wink: